### PR TITLE
tests/share/draw-test: fails

### DIFF
--- a/simple-qr/tests/share/draw-test.rkt
+++ b/simple-qr/tests/share/draw-test.rkt
@@ -2,7 +2,7 @@
 
 (require rackunit/text-ui)
 
-(require rackunit "../../share/draw/draw.rkt")
+(require rackunit "../../share/draw/lib.rkt")
 
 (define test-func
   (test-suite 


### PR DESCRIPTION
    raco test: (submod simple-qr/tests/share/draw-test.rkt test)
    draw-test.rkt:14:23: locate-brick: unbound identifier

require share/draw/lib rather than share/draw/draw